### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Cocoapods Version](http://img.shields.io/cocoapods/v/GooglePlusShareActivity.svg?style=flat)](http://cocoapods.org/?q=GooglePlusShareActivity) [![License](http://img.shields.io/cocoapods/l/GooglePlusShareActivity.svg?style=flat)](https://github.com/lysannschlegel/GooglePlusShareActivity/blob/master/LICENSE)
+[![CocoaPods Version](http://img.shields.io/cocoapods/v/GooglePlusShareActivity.svg?style=flat)](http://cocoapods.org/?q=GooglePlusShareActivity) [![License](http://img.shields.io/cocoapods/l/GooglePlusShareActivity.svg?style=flat)](https://github.com/lysannschlegel/GooglePlusShareActivity/blob/master/LICENSE)
 
 This library provides a UIActivity subclass for Google+ sharing. It uses the native share builder API from the official Google+ iOS SDK for sharing, and the GPPSignIn API for signing in.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
